### PR TITLE
ci: add CodeQL advanced analysis workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/backend-ci.yml"
+      - ".github/workflows/*.yml"
 
 defaults:
   run:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,76 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+      - "**.txt"
+      - ".env.example"
+      - "docs/**"
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+      - "**.txt"
+      - ".env.example"
+      - "docs/**"
+  schedule:
+    - cron: "30 21 * * 4"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+            source-root: backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        if: matrix.language == 'python'
+        run: |
+          pip install uv
+          uv sync --directory backend
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+          source-root: ${{ matrix.source-root || '.' }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
Adds a CodeQL Advanced analysis workflow for automated security scanning.

## What's included
- Triggers on push and PR to `main`, plus a weekly scheduled scan (Thursdays 21:30 UTC)
- Scans GitHub Actions workflows and Python backend code
- Uses `security-extended` query pack for broader CWE coverage
- Installs project dependencies via `uv` before analysis for accurate import resolution
- Skips analysis on non-code changes (docs, markdown, etc.)
- Concurrency group cancels redundant in-progress runs on the same ref

## Notes
- `javascript-typescript` matrix entry is intentionally omitted until the `frontend/` directory is introduced
- `source-root` is scoped to `backend/` for the Python analyzer to avoid cross-language noise