### PR TITLE
fix: DB stability

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -4,7 +4,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import settings
 
 engine = create_async_engine(
-    str(settings.DATABASE_URL.get_secret_value()), echo=False, pool_pre_ping=True
+    str(settings.DATABASE_URL.get_secret_value()),
+    echo=False,
+    pool_pre_ping=True,
+    connect_args={"prepared_statement_cache_size": 0},
 )
 
 


### PR DESCRIPTION
## Summary
Infrastructure fixe addressing a production error and a critical test environment flaw.

## Changes

### Disable asyncpg prepared statement cache
Asyncpg caches prepared statements at the connection level. After a schema change, these cached plans become stale, causing `InvalidCachedStatementError` on the first request post-migration. Subsequent requests succeed due to asyncpg's self-healing, but the initial caller receives a 500.

Fixed by setting `prepared_statement_cache_size=0` in `connect_args` on the async engine.

## Testing
- Verified login no longer returns 500 after running migrations
- Verified live data is unaffected after running the full test suite

## Related Issues
N/A